### PR TITLE
Updated Gradle to version 3.4.1 and replaced the deprecated syntax in…

### DIFF
--- a/NurApiAndroid/build.gradle
+++ b/NurApiAndroid/build.gradle
@@ -23,7 +23,7 @@ android {
     buildToolsVersion '28.0.3'
 
     /* Always remove NurApi.jar when doing clean build. Will downloaded in preBuild step */
-    clean << {
+    clean  {
         def f = new File('NurApiAndroid/libs/NurApi.jar')
         if (f.exists()) {
             println 'Deleted NurApi.jar'
@@ -32,8 +32,7 @@ android {
     }
 
     /* Download NurApi.jar if missing */
-    /*
-    preBuild << {
+    preBuild  {
         def f = new File('NurApiAndroid/libs/NurApi.jar')
         if (!f.exists()) {
             println 'Downloading latest NurApi.jar'
@@ -41,7 +40,6 @@ android {
             println 'Done'
         }
     }
-    */
 
     android.libraryVariants.all { variant ->
         variant.outputs.all {
@@ -53,13 +51,15 @@ android {
     }
 
     android.libraryVariants.all { variant ->
-        variant.assemble.doLast {
-            if ("${variant.name}" == "release") {
-                copy {
-                    from('build/outputs/aar') {
-                        include 'NurApiAndroid.aar'
+        variant.getAssembleProvider().configure() {
+            it.doLast {
+                if ("${variant.name}" == "release") {
+                    copy {
+                        from('build/outputs/aar') {
+                            include 'NurApiAndroid.aar'
+                        }
+                        into '../prebuilt'
                     }
-                    into '../prebuilt'
                 }
             }
         }
@@ -77,7 +77,7 @@ task sourcesJar(type: Jar) {
 }
 
 dependencies {
-    compileOnly fileTree(include: ['*.jar'], dir: 'libs')
+    api fileTree(include: ['*.jar'], dir: 'libs')
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     implementation 'no.nordicsemi.android.support.v18:scanner:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 21 13:32:12 EET 2017
+#Wed Jul 24 16:08:26 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
… build.gradle.

Hi,
when the .aar file is build with the current project the NurApi.jar does not get included. A Gradle-update solved the problem for me so I made a pull request out of this.

I attached a picture that will hopefully explain what I mean a little better. The "compileOnly".aar is created with the current project and the "api".aar with the Gradleupdate:
![Comparison](https://user-images.githubusercontent.com/33830649/61862095-91411100-aecd-11e9-9bab-8c5dfaa52224.jpg)

Regards,
Gerald